### PR TITLE
Fix null webserver reference caused by authentication initialization order

### DIFF
--- a/esp3d/src/include/esp3d_version.h
+++ b/esp3d/src/include/esp3d_version.h
@@ -22,7 +22,7 @@
 #define _VERSION_ESP3D_H
 
 // version and sources location
-#define FW_VERSION "3.1.2"
+#define FW_VERSION "3.1.3"
 #define REPOSITORY "https://github.com/luc-github/ESP3D/tree/3.0"
 
 #endif  //_VERSION_ESP3D_H

--- a/esp3d/src/modules/authentication/authentication_service.cpp
+++ b/esp3d/src/modules/authentication/authentication_service.cpp
@@ -116,7 +116,9 @@ uint32_t AuthenticationService::getSessionTimeout() { return _sessionTimeout; }
 #endif  // HTTP_FEATURE
 
 bool AuthenticationService::begin() {
-  end();
+#if defined(HTTP_FEATURE)
+  ClearAllSessions();
+#endif
   update(); 
   return true; 
 }


### PR DESCRIPTION
## Summary

Fix a crash during HTTP authentication caused by `AuthenticationService::begin()` resetting the web server reference.

## Root cause

`AuthenticationService::begin()` previously called `end()`, which performed a full reset of the authentication service state, including clearing the `_webserver` pointer.

When `begin_session()` had already initialized the web server reference, a subsequent call to `begin()` unintentionally invalidated it. During login, the authentication code later dereferenced the cleared pointer, resulting in a `LoadProhibited` (Guru Meditation) exception.

## Changes

Instead of calling `end()`, `begin()` now only clears existing authentication sessions by calling `ClearAllSessions()`.

This preserves the initialized web server reference while still resetting the session state as intended.

## Benefits

- Prevents null pointer dereferences during HTTP login.
- Preserves the authentication service initialization state.
- Limits the reset performed by `begin()` to session data only.